### PR TITLE
Add Case property to FormatConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can also pass `FormatConfig` object built by builder:
 SqlFormatter.Format("SELECT * FROM tbl",
   FormatConfig.Builder()
     .Indent("    ") // Defaults to two spaces
-    .Uppercase(true) // Defaults to false (not safe to use when SQL dialect has case-sensitive identifiers)
+    .Case(CaseTypes.UPPER) // Defaults to NONE (not safe to use when SQL dialect has case-sensitive identifiers)
     .LinesBetweenQueries(2) // Defaults to 1
     .MaxColumnLength(100) // Defaults to 50
     .Params(new List<string>{"a", "b", "c"}) // Dictionary or List. See Placeholders replacement.

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -6,13 +6,13 @@ namespace SQL.Formatter.Test
 {
     public class FormatConfigTest
     {
-        private static readonly SqlFormatter.Formatter Formatter = SqlFormatter.Of(Dialect.StandardSql);
+        private static readonly SqlFormatter.Formatter s_formatter = SqlFormatter.Of(Dialect.StandardSql);
 
         [Fact]
         public void Upper_FormatsKeywordsInUppercase()
         {
             var cfg = FormatConfig.Builder().Case(CaseTypes.UPPER).Build();
-            var result = Formatter.Format("select id from users where id = 1", cfg);
+            var result = s_formatter.Format("select id from users where id = 1", cfg);
 
             Assert.Equal(
                 "SELECT\n"
@@ -30,7 +30,7 @@ namespace SQL.Formatter.Test
 #pragma warning disable CS0618
             var cfg = FormatConfig.Builder().Uppercase(true).Build();
 #pragma warning restore CS0618
-            var result = Formatter.Format("select id from users where id = 1", cfg);
+            var result = s_formatter.Format("select id from users where id = 1", cfg);
 
             Assert.Equal(
                 "SELECT\n"
@@ -48,7 +48,7 @@ namespace SQL.Formatter.Test
 #pragma warning disable CS0618
             var cfg = FormatConfig.Builder().Uppercase(false).Build();
 #pragma warning restore CS0618
-            var result = Formatter.Format("select id FROM users", cfg);
+            var result = s_formatter.Format("select id FROM users", cfg);
 
             Assert.Equal(
                 "select\n"
@@ -62,7 +62,7 @@ namespace SQL.Formatter.Test
         public void Lower_FormatsKeywordsInLowercase()
         {
             var cfg = FormatConfig.Builder().Case(CaseTypes.LOWER).Build();
-            var result = Formatter.Format("SELECT id FROM Users WHERE id = 1", cfg);
+            var result = s_formatter.Format("SELECT id FROM Users WHERE id = 1", cfg);
 
             Assert.Equal(
                 "select\n"
@@ -104,7 +104,7 @@ namespace SQL.Formatter.Test
                 .Case(CaseTypes.UPPER)
                 .Build();
 
-            var result = Formatter.Format("select id from users", cfg);
+            var result = s_formatter.Format("select id from users", cfg);
 
             Assert.Equal(
                 "SELECT\n"
@@ -122,7 +122,7 @@ namespace SQL.Formatter.Test
                 .Case(CaseTypes.LOWER)
                 .Build();
 
-            var result = Formatter.Format("SELECT id FROM users", cfg);
+            var result = s_formatter.Format("SELECT id FROM users", cfg);
 
             Assert.Equal(
                 "select\n"
@@ -136,7 +136,7 @@ namespace SQL.Formatter.Test
         public void NeitherUppercaseNorLowercase_PreservesKeywordCase()
         {
             var cfg = FormatConfig.Builder().Build();
-            var result = Formatter.Format("SeLeCt id FrOm users", cfg);
+            var result = s_formatter.Format("SeLeCt id FrOm users", cfg);
 
             Assert.Equal(
                 "SeLeCt\n"
@@ -150,7 +150,7 @@ namespace SQL.Formatter.Test
         public void None_PreservesKeywordCase()
         {
             var cfg = FormatConfig.Builder().Case(CaseTypes.NONE).Build();
-            var result = Formatter.Format("SeLeCt id FrOm users", cfg);
+            var result = s_formatter.Format("SeLeCt id FrOm users", cfg);
 
             Assert.Equal(
                 "SeLeCt\n"

--- a/SQL.Formatter.Test/FormatConfigTest.cs
+++ b/SQL.Formatter.Test/FormatConfigTest.cs
@@ -1,0 +1,175 @@
+﻿using SQL.Formatter.Core;
+using SQL.Formatter.Language;
+using Xunit;
+
+namespace SQL.Formatter.Test
+{
+    public class FormatConfigTest
+    {
+        private static readonly SqlFormatter.Formatter Formatter = SqlFormatter.Of(Dialect.StandardSql);
+
+        [Fact]
+        public void Upper_FormatsKeywordsInUppercase()
+        {
+            var cfg = FormatConfig.Builder().Case(CaseTypes.UPPER).Build();
+            var result = Formatter.Format("select id from users where id = 1", cfg);
+
+            Assert.Equal(
+                "SELECT\n"
+                + "  id\n"
+                + "FROM\n"
+                + "  users\n"
+                + "WHERE\n"
+                + "  id = 1",
+                result);
+        }
+
+        [Fact]
+        public void Uppercase_FormatsKeywordsInUppercase()
+        {
+#pragma warning disable CS0618
+            var cfg = FormatConfig.Builder().Uppercase(true).Build();
+#pragma warning restore CS0618
+            var result = Formatter.Format("select id from users where id = 1", cfg);
+
+            Assert.Equal(
+                "SELECT\n"
+                + "  id\n"
+                + "FROM\n"
+                + "  users\n"
+                + "WHERE\n"
+                + "  id = 1",
+                result);
+        }
+
+        [Fact]
+        public void Uppercase_False_PreservesKeywordCase()
+        {
+#pragma warning disable CS0618
+            var cfg = FormatConfig.Builder().Uppercase(false).Build();
+#pragma warning restore CS0618
+            var result = Formatter.Format("select id FROM users", cfg);
+
+            Assert.Equal(
+                "select\n"
+                + "  id\n"
+                + "FROM\n"
+                + "  users",
+                result);
+        }
+
+        [Fact]
+        public void Lower_FormatsKeywordsInLowercase()
+        {
+            var cfg = FormatConfig.Builder().Case(CaseTypes.LOWER).Build();
+            var result = Formatter.Format("SELECT id FROM Users WHERE id = 1", cfg);
+
+            Assert.Equal(
+                "select\n"
+                + "  id\n"
+                + "from\n"
+                + "  Users\n"
+                + "where\n"
+                + "  id = 1",
+                result);
+        }
+
+        [Fact]
+        public void Upper_ClearsLower()
+        {
+            var cfg = FormatConfig.Builder()
+                .Case(CaseTypes.LOWER)
+                .Case(CaseTypes.UPPER)
+                .Build();
+
+            Assert.Equal(CaseTypes.UPPER, cfg.Case);
+        }
+
+        [Fact]
+        public void Lower_ClearsUpper()
+        {
+            var cfg = FormatConfig.Builder()
+                .Case(CaseTypes.UPPER)
+                .Case(CaseTypes.LOWER)
+                .Build();
+
+            Assert.Equal(CaseTypes.LOWER, cfg.Case);
+        }
+
+        [Fact]
+        public void Upper_ClearsLower_FormatsUppercase()
+        {
+            var cfg = FormatConfig.Builder()
+                .Case(CaseTypes.LOWER)
+                .Case(CaseTypes.UPPER)
+                .Build();
+
+            var result = Formatter.Format("select id from users", cfg);
+
+            Assert.Equal(
+                "SELECT\n"
+                + "  id\n"
+                + "FROM\n"
+                + "  users",
+                result);
+        }
+
+        [Fact]
+        public void Lower_ClearsUpper_FormatsLowercase()
+        {
+            var cfg = FormatConfig.Builder()
+                .Case(CaseTypes.UPPER)
+                .Case(CaseTypes.LOWER)
+                .Build();
+
+            var result = Formatter.Format("SELECT id FROM users", cfg);
+
+            Assert.Equal(
+                "select\n"
+                + "  id\n"
+                + "from\n"
+                + "  users",
+                result);
+        }
+
+        [Fact]
+        public void NeitherUppercaseNorLowercase_PreservesKeywordCase()
+        {
+            var cfg = FormatConfig.Builder().Build();
+            var result = Formatter.Format("SeLeCt id FrOm users", cfg);
+
+            Assert.Equal(
+                "SeLeCt\n"
+                + "  id\n"
+                + "FrOm\n"
+                + "  users",
+                result);
+        }
+
+        [Fact]
+        public void None_PreservesKeywordCase()
+        {
+            var cfg = FormatConfig.Builder().Case(CaseTypes.NONE).Build();
+            var result = Formatter.Format("SeLeCt id FrOm users", cfg);
+
+            Assert.Equal(
+                "SeLeCt\n"
+                + "  id\n"
+                + "FrOm\n"
+                + "  users",
+                result);
+        }
+
+        [Theory]
+        [InlineData(CaseTypes.NONE, false)]
+        [InlineData(CaseTypes.UPPER, true)]
+        [InlineData(CaseTypes.LOWER, false)]
+        public void Case_SetsUppercaseCorrectly(CaseTypes caseType, bool expectedUppercase)
+        {
+            var cfg = FormatConfig.Builder().Case(caseType).Build();
+#pragma warning disable CS0618
+            Assert.Equal(expectedUppercase, cfg.Uppercase);
+#pragma warning restore CS0618
+        }
+    }
+}

--- a/SQL.Formatter/Core/AbstractFormatter.cs
+++ b/SQL.Formatter/Core/AbstractFormatter.cs
@@ -282,7 +282,7 @@ namespace SQL.Formatter.Core
 
         protected virtual string Show(Token token)
         {
-            if (_cfg.Uppercase
+            if (_cfg.Case > CaseTypes.NONE
                 && (token.Type == TokenTypes.RESERVED
                     || token.Type == TokenTypes.RESERVED_TOP_LEVEL
                     || token.Type == TokenTypes.RESERVED_TOP_LEVEL_NO_INDENT
@@ -291,7 +291,7 @@ namespace SQL.Formatter.Core
                     || token.Type == TokenTypes.CLOSE_PAREN))
             {
                 // Note: If memory is still tight, caching upper-case values at the token generation stage is even better.
-                return token.Value.ToUpper();
+                return _cfg.Case == CaseTypes.UPPER ? token.Value.ToUpper() : token.Value.ToLower();
             }
 
             return token.Value;

--- a/SQL.Formatter/Core/CaseTypes.cs
+++ b/SQL.Formatter/Core/CaseTypes.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace SQL.Formatter.Core
 {
     public enum CaseTypes

--- a/SQL.Formatter/Core/CaseTypes.cs
+++ b/SQL.Formatter/Core/CaseTypes.cs
@@ -1,4 +1,4 @@
-namespace SQL.Formatter.Core
+﻿namespace SQL.Formatter.Core
 {
     public enum CaseTypes
     {

--- a/SQL.Formatter/Core/CaseTypes.cs
+++ b/SQL.Formatter/Core/CaseTypes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SQL.Formatter.Core
+{
+    public enum CaseTypes
+    {
+        NONE,
+        UPPER,
+        LOWER,
+    }
+}

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -24,16 +24,15 @@ namespace SQL.Formatter.Core
             Params parameters,
             bool uppercase,
             int linesBetweenQueries,
-            bool skipWhitespaceNearBlockParentheses) 
-            
+            bool skipWhitespaceNearBlockParentheses)
             : this(
-                  indent, 
-                  maxColumnLength, 
-                  parameters, 
-                  uppercase ? CaseTypes.UPPER : CaseTypes.NONE, 
-                  linesBetweenQueries, 
+                  indent,
+                  maxColumnLength,
+                  parameters,
+                  uppercase ? CaseTypes.UPPER : CaseTypes.NONE,
+                  linesBetweenQueries,
                   skipWhitespaceNearBlockParentheses)
-        {            
+        {
         }
 
         public FormatConfig(

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -55,7 +55,6 @@ namespace SQL.Formatter.Core
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
         }
 
-
         public static FormatConfigBuilder Builder()
         {
             return new FormatConfigBuilder();

--- a/SQL.Formatter/Core/FormatConfig.cs
+++ b/SQL.Formatter/Core/FormatConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SQL.Formatter.Core
 {
@@ -10,25 +11,50 @@ namespace SQL.Formatter.Core
         public readonly string Indent;
         public readonly int MaxColumnLength;
         public readonly Params Parameters;
+        [Obsolete("Use Case instead of Uppercase")]
         public readonly bool Uppercase;
+        public readonly CaseTypes Case;
         public readonly int LinesBetweenQueries;
         public readonly bool SkipWhitespaceNearBlockParentheses;
 
+        [Obsolete("Use the constructor with caseType instead of uppercase")]
         public FormatConfig(
             string indent,
             int maxColumnLength,
             Params parameters,
             bool uppercase,
             int linesBetweenQueries,
+            bool skipWhitespaceNearBlockParentheses) 
+            
+            : this(
+                  indent, 
+                  maxColumnLength, 
+                  parameters, 
+                  uppercase ? CaseTypes.UPPER : CaseTypes.NONE, 
+                  linesBetweenQueries, 
+                  skipWhitespaceNearBlockParentheses)
+        {            
+        }
+
+        public FormatConfig(
+            string indent,
+            int maxColumnLength,
+            Params parameters,
+            CaseTypes caseType,
+            int linesBetweenQueries,
             bool skipWhitespaceNearBlockParentheses)
         {
             Indent = indent;
             MaxColumnLength = maxColumnLength;
             Parameters = parameters == null ? Params.Empty : parameters;
-            Uppercase = uppercase;
+            Case = caseType;
+#pragma warning disable CS0618
+            Uppercase = caseType == CaseTypes.UPPER;
+#pragma warning restore CS0618
             LinesBetweenQueries = linesBetweenQueries;
             SkipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
         }
+
 
         public static FormatConfigBuilder Builder()
         {
@@ -40,7 +66,7 @@ namespace SQL.Formatter.Core
             private string _indent = DefaultIndent;
             private int _maxColumnLength = DefaultColumnMaxLength;
             private Params _parameters;
-            private bool _uppercase;
+            private CaseTypes _case;
             private int _linesBetweenQueries;
             private bool _skipWhitespaceNearBlockParentheses;
 
@@ -76,9 +102,17 @@ namespace SQL.Formatter.Core
                 return Params(Core.Params.Of(parameters));
             }
 
+            [Obsolete("Use Case instead of Uppercase")]
             public FormatConfigBuilder Uppercase(bool uppercase)
             {
-                _uppercase = uppercase;
+                _case = uppercase ? CaseTypes.UPPER : CaseTypes.NONE;
+
+                return this;
+            }
+
+            public FormatConfigBuilder Case(CaseTypes caseType)
+            {
+                _case = caseType;
                 return this;
             }
 
@@ -100,7 +134,7 @@ namespace SQL.Formatter.Core
                     _indent,
                     _maxColumnLength,
                     _parameters,
-                    _uppercase,
+                    _case,
                     _linesBetweenQueries,
                     _skipWhitespaceNearBlockParentheses);
             }


### PR DESCRIPTION
My team prefers lowercasing sql reserved words.

This PR replaces the boolean `Uppercase` property with a `CaseTypes` enum supporting   NONE, UPPER, and LOWER. The formatter's `Show()` method is updated to apply `.ToLower()` or `.ToUpper()` based on the enum value.

The previous bool `uppercase` constructor and `Uppercase(bool)` builder method are preserved but marked `[Obsolete]`, delegating to the new `CaseTypes`-based path. The `Uppercase` property is similarly obsoleted but kept for backwards compatibility, deriving its value from `Case == CaseTypes.UPPER`.

Tests cover all three `CaseTypes` values for both formatting behavior and the legacy `Uppercase` property.